### PR TITLE
Fix s3

### DIFF
--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -6,7 +6,8 @@ This document highlights major changes and additions across releases.
 v2509.0.2
 ----------
 * Improved logging.
-
+* Fix S3 "flat directory bug".
+* Drop dataset versioning if crawl path if past version position.
 
 v2509.0.1
 ----------

--- a/src/metadata_crawler/backends/s3.py
+++ b/src/metadata_crawler/backends/s3.py
@@ -72,8 +72,14 @@ class S3Path(PathTemplate):
     ) -> AsyncIterator[str]:
         """Retrieve sub directories of directory."""
         client = await self._get_client()
-        for _content in await client._ls(str(path)):
-            yield _content
+        path = str(path)
+        if await self.is_file(path):
+            yield path
+        else:
+            for _content in await client._lsdir(path):
+                size: int = _content.get("size") or 0
+                if _content.get("type", "") == "directory" or size > 0:
+                    yield _content.get("name", "")
 
     async def rglob(
         self, path: str | Path | pathlib.Path, glob_pattern: str = "*"

--- a/src/metadata_crawler/backends/s3.py
+++ b/src/metadata_crawler/backends/s3.py
@@ -71,11 +71,9 @@ class S3Path(PathTemplate):
         self, path: Union[str, Path, pathlib.Path]
     ) -> AsyncIterator[str]:
         """Retrieve sub directories of directory."""
-        path = str(path)
         client = await self._get_client()
-        for _content in await client._lsdir(path):
-            if _content.get("type", "") == "directory":
-                yield f'{_content.get("name", "")}'
+        for _content in await client._ls(str(path)):
+            yield _content
 
     async def rglob(
         self, path: str | Path | pathlib.Path, glob_pattern: str = "*"

--- a/src/metadata_crawler/data_collector.py
+++ b/src/metadata_crawler/data_collector.py
@@ -253,6 +253,13 @@ class DataCollector:
                 pos = self.config.max_directory_tree_level(
                     path, drs_type=drs_type
                 )
+                if pos < 0:
+                    logger.warning(
+                        "Can't define latest version of versioned dataset."
+                        " This might lead to unexpected results. Try adjusting"
+                        " your search path."
+                    )
+
                 await self._iter_content(
                     drs_type, path, pos, is_versioned=pos > 0
                 )

--- a/tests/test_crawl_s3.py
+++ b/tests/test_crawl_s3.py
@@ -27,6 +27,53 @@ def test_crawl_s3_obs(
     assert len(cat.latest.read()) > 0
 
 
+def test_crawl_s3_dir(
+    drs_config_path: Path,
+    storage_options: Dict[str, str],
+) -> None:
+    """Test crawling a flat directory."""
+    cat_file = "s3://test/metadata_crawler/tests/data-flat.yml"
+    inp_dir = (
+        "s3://test/data/obs/observations/grid/CPC/CPC/cmorph/"
+        "30min/atmos/30min/r1i1p1/v20210618/pr"
+    )
+    add(
+        cat_file,
+        drs_config_path,
+        data_store_prefix="s3://test/metadata_crawler/tests/metadata",
+        batch_size=3,
+        n_procs=1,
+        data_object=[inp_dir],
+        storage_options=storage_options,
+    )
+    cat = intake.open_catalog(cat_file, storage_options=storage_options)
+    assert len(cat.latest.read()) > 0
+
+
+def test_crawl_s3_single_file(
+    drs_config_path: Path,
+    storage_options: Dict[str, str],
+) -> None:
+    """Test crawling a flat directory."""
+    cat_file = "s3://test/metadata_crawler/tests/data-flat.yml"
+    inp_file = (
+        "s3://test/data/obs/observations/grid/CPC/CPC/cmorph"
+        "/30min/atmos/30min/r1i1p1/v20210618/pr"
+        "/pr_30min_CPC_cmorph_r1i1p1_201609020000-201609020030.nc"
+    )
+    add(
+        cat_file,
+        drs_config_path,
+        data_store_prefix="s3://test/metadata_crawler/tests/metadata",
+        batch_size=3,
+        n_procs=1,
+        data_object=[inp_file],
+        storage_options=storage_options,
+    )
+    cat = intake.open_catalog(cat_file, storage_options=storage_options)
+    assert len(cat.latest.read()) > 0
+
+
 def test_crawl_s3_cmip6(
     drs_config_path: Path, storage_options: Dict[str, str]
 ) -> None:


### PR DESCRIPTION
@mo-dkrz 

This PR fixes #16 . The behaviour is now the same as pathlib's `iterdir`. Files and sub-directories are yielded as well as direct yield of files.

I've also noticed and fixed a bug that occurred when crawling versioned dataset with crawl path that is beyond the version. 

```console
mdc add data.yml \ 
  -c drs_config.toml \
  -d "s3://test/data/obs/observations/grid/CPC/CPC/cmorph/30min/atmos/30min/r1i1p1/v20210618/pr"
``` 

The crawler will give a warning and treat this dataset as `latest`. 