### PR TITLE
Better logging in non interactive modes

### DIFF
--- a/src/metadata_crawler/__init__.py
+++ b/src/metadata_crawler/__init__.py
@@ -1,20 +1,9 @@
 """Metadata Crawler API high level functions."""
 
-import asyncio
 from pathlib import Path
-from types import ModuleType
 from typing import Any, Dict, List, Literal, Optional, Union, cast, overload
 
 from tomlkit import TOMLDocument
-
-try:
-    import uvloop
-
-    use_uvloop = True
-except ImportError:
-
-    use_uvloop = False  # pragma: no cover
-
 
 from ._version import __version__
 from .api.config import ConfigMerger, DRSConfig
@@ -22,14 +11,9 @@ from .api.metadata_stores import CatalogueBackendType, IndexName
 from .data_collector import DataCollector
 from .logger import logger
 from .run import async_add, async_delete, async_index
+from .utils.loop import get_async_model
 
-async_model: ModuleType
-
-if use_uvloop:
-    async_model = uvloop
-    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
-else:
-    async_model = asyncio  # pragma: no cover
+async_model = get_async_model()
 
 __all__ = [
     "logger",
@@ -42,6 +26,7 @@ __all__ = [
     "async_index",
     "async_delete",
     "async_add",
+    "async_model",
 ]
 
 

--- a/src/metadata_crawler/data_collector.py
+++ b/src/metadata_crawler/data_collector.py
@@ -144,16 +144,12 @@ class DataCollector:
         silent = self.ingest_queue.silent
         if iterable:
             try:
-                _sub_dirs = self.config.datasets[drs_type].backend.iterdir(
-                    search_dir
-                )
+                _sub_dirs = self.config.datasets[drs_type].backend.iterdir(search_dir)
             except Exception as error:
                 logger.error(error)
                 return
         else:
-            _sub_dirs = cast(
-                AsyncIterator[str], create_async_iterator([search_dir])
-            )
+            _sub_dirs = cast(AsyncIterator[str], create_async_iterator([search_dir]))
         rank = 0
         sub_dirs = []
         async for _dir in _sub_dirs:
@@ -165,9 +161,7 @@ class DataCollector:
             ):
                 if self._test_env():
                     return
-                await self.ingest_queue.put(
-                    _inp, drs_type, name=self.index_name.all
-                )
+                await self.ingest_queue.put(_inp, drs_type, name=self.index_name.all)
                 if rank == 0 or is_versioned is False:
                     await self.ingest_queue.put(
                         _inp, drs_type, name=self.index_name.latest
@@ -222,9 +216,7 @@ class DataCollector:
 
         if op is not None:
             # enqueue the heavy scan; workers will run _ingest_dir concurrently
-            await self._scan_queue.put(
-                (drs_type, inp_dir, iterable, is_versioned)
-            )
+            await self._scan_queue.put((drs_type, inp_dir, iterable, is_versioned))
             return
 
         # otherwise, recurse sequentially (cheap) — no task per directory
@@ -265,9 +257,7 @@ class DataCollector:
                         " your search path."
                     )
 
-                await self._iter_content(
-                    drs_type, path, pos, is_versioned=is_versioned
-                )
+                await self._iter_content(drs_type, path, pos, is_versioned=is_versioned)
 
             # wait until all queued scan items are processed
             await self._scan_queue.join()
@@ -276,9 +266,7 @@ class DataCollector:
             for _ in range(self._scan_concurrency):
                 await self._scan_queue.put(None)
 
-        logger.info(
-            "%i ingestion tasks have been completed", len(self._search_objects)
-        )
+        logger.info("%i ingestion tasks have been completed", len(self._search_objects))
         self.ingest_queue.join_all_tasks()
         if self.ingest_queue.silent is False:
             self._print_status.clear()

--- a/src/metadata_crawler/logger.py
+++ b/src/metadata_crawler/logger.py
@@ -1,8 +1,12 @@
 """Logging utilities."""
 
+import asyncio
+import concurrent.futures
 import logging
 import logging.config
+import multiprocessing
 import os
+import sys
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Any, Optional, cast
@@ -10,6 +14,8 @@ from typing import Any, Optional, cast
 import appdirs
 from rich.console import Console
 from rich.logging import RichHandler
+
+from .utils.loop import get_async_model
 
 THIS_NAME = "metadata-crawler"
 
@@ -49,7 +55,14 @@ class Logger(logging.Logger):
     logfmt: str = "%(name)s: %(message)s"
     filelogfmt: str = "%(asctime)s %(levelname)s: %(name)s - %(message)s"
     datefmt: str = "%Y-%m-%dT%H:%M:%S"
-    no_debug: list[str] = ["watchfiles", "httpcore", "pymongo", "pika"]
+    no_debug: list[str] = [
+        "watchfiles",
+        "httpcore",
+        "pymongo",
+        "pika",
+        "uvloop",
+        "asyncio",
+    ]
 
     def __init__(
         self,
@@ -66,14 +79,21 @@ class Logger(logging.Logger):
         self.file_format = logging.Formatter(self.filelogfmt, self.datefmt)
         self._logger_file_handle: Optional[RotatingFileHandler] = None
         self._logger_stream_handle = RichHandler(
-            rich_tracebacks=True,
+            rich_tracebacks=self.is_interactive_environment(),
             tracebacks_max_frames=10,
             tracebacks_extra_lines=5,
             show_path=True,
+            tracebacks_suppress=[
+                get_async_model(),
+                asyncio,
+                concurrent.futures,
+                multiprocessing,
+            ],
             console=Console(
                 soft_wrap=False,
                 force_jupyter=False,
                 stderr=True,
+                force_terminal=self.is_interactive_environment(),
             ),
         )
         self._logger_stream_handle.setFormatter(logger_format)
@@ -87,6 +107,12 @@ class Logger(logging.Logger):
             if os.getenv("MDC_LOG_INIT", "0") == "1"
             else None
         )
+
+    @staticmethod
+    def is_interactive_environment() -> bool:
+        """Decide whether we are in an interactive environment."""
+        _isatty = int(getattr(sys.stdout, "isatty", lambda: False)())
+        return bool(int(os.getenv("MDC_INTERACTIVE", str(_isatty))))
 
     def set_level(self, level: int) -> None:
         """Set the logger level to level."""
@@ -140,9 +166,7 @@ def get_level_from_verbosity(verbosity: int) -> int:
     return max(logging.CRITICAL - 10 * verbosity, -1)
 
 
-def apply_verbosity(
-    level: Optional[int] = None, suffix: Optional[str] = None
-) -> int:
+def apply_verbosity(level: Optional[int] = None, suffix: Optional[str] = None) -> int:
     """Set the logging level of the handlers to a certain level."""
     level = logger.level if level is None else level
     old_level = logger.level

--- a/src/metadata_crawler/utils/__init__.py
+++ b/src/metadata_crawler/utils/__init__.py
@@ -5,7 +5,6 @@ import logging
 import multiprocessing as mp
 import multiprocessing.context as mctx
 import os
-import sys
 import time
 from datetime import datetime, timedelta
 from importlib.metadata import entry_points
@@ -125,7 +124,12 @@ class FilesystemLike(Protocol):
 
 Counter: TypeAlias = ValueLike[int]
 PrintLock = mp.Lock()
-Console = rich.console.Console(force_terminal=sys.stdout.isatty(), stderr=True)
+Console = rich.console.Console(
+    force_terminal=logger.is_interactive_environment(),
+    force_jupyter=False,
+    soft_wrap=False,
+    stderr=True,
+)
 
 
 class MetadataCrawlerException(Exception):

--- a/src/metadata_crawler/utils/loop.py
+++ b/src/metadata_crawler/utils/loop.py
@@ -1,0 +1,18 @@
+"""Define the asyncio loop."""
+
+import asyncio
+from functools import lru_cache
+from types import ModuleType
+
+
+@lru_cache(maxsize=None)
+def get_async_model() -> ModuleType:
+    """Get the asyncio module. Prefer uvloop over asyncio if installed."""
+    try:
+        import uvloop
+
+        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+
+        return uvloop
+    except ImportError:
+        return asyncio  # pragma: no cover


### PR DESCRIPTION
When using metdata-crawler as a service (in envs without tty) logger output got squeezed into tiny columns.

This tries to fix the problem.